### PR TITLE
目のボーンの左右を入れ替え

### DIFF
--- a/readfacevmd.cc
+++ b/readfacevmd.cc
@@ -133,8 +133,8 @@ void add_gaze_pose(vector<VMD_Frame>& frame_vec, cv::Point3f gazedir_left, cv::P
   rot_left = Quaterniond::Identity().slerp(amp_each, rot_left);
 
   add_rotation_pose(frame_vec, rot_both, frame_number, u8"両目");
-  add_rotation_pose(frame_vec, rot_left, frame_number, u8"左目");
-  add_rotation_pose(frame_vec, rot_right, frame_number, u8"右目");
+  add_rotation_pose(frame_vec, rot_right, frame_number, u8"左目");
+  add_rotation_pose(frame_vec, rot_left, frame_number, u8"右目");
 }
 
 // 表情フレームを VMD_Morph の vector に追加する 


### PR DESCRIPTION
`GazeAnalysis::EstimateGaze(face_model, gazedir_left, cap.fx, cap.fy, cap.cx, cap.cy, true);`
で取得した左側の目の向きから、目の角度を求めて"左目"に割り当てていますが、gazedir_leftは画面から見て左のことで、モデルに対しては右目になると思われます。

[https://github.com/TadasBaltrusaitis/OpenFace/blob/master/lib/local/GazeAnalyser/src/GazeEstimation.cpp](https://github.com/TadasBaltrusaitis/OpenFace/blob/master/lib/local/GazeAnalyser/src/GazeEstimation.cpp)
`GazeAnalysis::EstimateGaze()`内で、`if (left_eye) eyeIdx = 0; `として、`cv::Mat eyeballCentreMat = (faceLdmks3d.row(36+eyeIdx*6) + faceLdmks3d.row(39+eyeIdx*6))/2.0f + (cv::Mat(rotMat)*offset).t();` のように左ならば、36,39番を目の位置の基準に使っています。

[Unity – Dlib FaceLandmark Detectorで顔認識](http://mizutanikirin.net/unity-dlib-facelandmark-detector%E3%81%A7%E9%A1%94%E8%AA%8D%E8%AD%98)
などを見ると、36,39番は左側(右目)になっています。
