### PR TITLE
いい加減な視線推定

### DIFF
--- a/readfacevmd.cc
+++ b/readfacevmd.cc
@@ -133,8 +133,8 @@ void add_gaze_pose(vector<VMD_Frame>& frame_vec, cv::Point3f gazedir_left, cv::P
   rot_left = Quaterniond::Identity().slerp(amp_each, rot_left);
 
   add_rotation_pose(frame_vec, rot_both, frame_number, u8"両目");
-  add_rotation_pose(frame_vec, rot_left, frame_number, u8"左目");
-  add_rotation_pose(frame_vec, rot_right, frame_number, u8"右目");
+  add_rotation_pose(frame_vec, rot_right, frame_number, u8"左目");
+  add_rotation_pose(frame_vec, rot_left, frame_number, u8"右目");
 }
 
 // 表情フレームを VMD_Morph の vector に追加する 

--- a/readfacevmd.cc
+++ b/readfacevmd.cc
@@ -118,21 +118,13 @@ void add_gaze_pose(vector<VMD_Frame>& frame_vec, cv::Point3f gazedir_left, cv::P
   rightdir.z() = gazedir_right.z;
   Quaterniond rot_right = Quaterniond::FromTwoVectors(front, rightdir);
 
-  // 両目の回転 = 左目と右目の回転の平均 とする
-  Quaterniond rot_both = rot_left.slerp(0.5, rot_right);
-  //Quaterniond rot_both = rot_left;
-  rot_left = rot_both.inverse() * rot_left;
-  rot_right = rot_both.inverse() * rot_right;
-
   // 目の回転量を補正
   // TODO: 補正係数の適切な値を決める
   const double amp_both = 1.0;
   const double amp_each = 0.25;
-  rot_both = Quaterniond::Identity().slerp(amp_both, rot_both);
   rot_right = Quaterniond::Identity().slerp(amp_each, rot_right);
   rot_left = Quaterniond::Identity().slerp(amp_each, rot_left);
 
-  add_rotation_pose(frame_vec, rot_both, frame_number, u8"両目");
   add_rotation_pose(frame_vec, rot_right, frame_number, u8"左目");
   add_rotation_pose(frame_vec, rot_left, frame_number, u8"右目");
 }


### PR DESCRIPTION
お目汚しです。
横を向いた時、さらに目が画面に対して奥側を向いた場合の視線方向が実際とズレることが多かったために、適当な補正を入れてみました。openCVなどを理解していないため、汚いコードになっているかと思います。

OpenFaceで使用している` GazeAnalysis::EstimateGaze()`の推定する黒目の深度と `LandmarkDetector`の推定する目の深度がズレていたため、Landmark側の深度で黒目の位置を補正してみました。
またオリジナルでは球と直線の交差判定を行っている部分を単なるベクトルの向きを得るだけにしています。
